### PR TITLE
Add modules to /version endpoint

### DIFF
--- a/pulp_smart_proxy/app/views.py
+++ b/pulp_smart_proxy/app/views.py
@@ -69,5 +69,10 @@ class VersionView(APIView):
         operation_id="version_read",
     )
     def get(self, request):
-        data = {"version": get_plugin_config("smart_proxy").version}
+        data = {
+            "version": get_plugin_config("smart_proxy").version,
+            "modules": {
+                "pulpcore": get_plugin_config("smart_proxy").version,
+            },
+        }
         return Response(data)

--- a/pulp_smart_proxy/app/views.py
+++ b/pulp_smart_proxy/app/views.py
@@ -70,7 +70,7 @@ class VersionView(APIView):
     )
     def get(self, request):
         data = {
-            "version": get_plugin_config("smart_proxy").version,
+            "version": get_plugin_config("core").version,
             "modules": {
                 "pulpcore": get_plugin_config("smart_proxy").version,
             },


### PR DESCRIPTION
The version API also returns the versions for each individual module that's enabled.

See https://github.com/theforeman/smart-proxy/blob/6624f2c22cf263dd49025a4af28d893a9e22ff52/modules/root/root_api.rb#L13-L21