### PR TITLE
Update upper bound to work with pulpcore 3.105

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "pulpcore>=3.49.0,<3.100",
+  "pulpcore>=3.49.0,<3.106",
 ]
 
 [project.urls]


### PR DESCRIPTION
Updates the upper bound to work with pulpcore 3.105 which Katello will pick up soon. I tested creating a repository and syncing it after installing this plugin with that version of Pulpcore.




### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
